### PR TITLE
minor enhancements to allow for cli creation of salted hash for manual insertion into database, as well as module option to allow the role principle class to be specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target/
+.idea

--- a/README.md
+++ b/README.md
@@ -32,16 +32,6 @@ Following list shows all configuration parameters:
 * roleQuery - SQL query for loading the associated roles of the authenticated user
 * debug - activate / deactivate debugging information (optional: default is false) 
 
-#### Database structure example
-```
-create table users (id bigint primary key, username varchar(255), salt varchar(255), password varchar(255));
-create table roles (id bigint primary key, name varchar(255));
-create table roles_users (role_id bigint, user_id bigint, constraint roles_users_role_id foreign key (role_id) references roles (id), constraint roles_users_user_id foreign key (user_id) references users (id));
-
-insert into users values (0, 'hawkeye', '8117ec859d0cf945fa9b28075f590707', '13e96bc7ade230967057dd138198dbd02491a8f6871f09b97c351b31a35b5878');
-insert into roles values (0, 'mohican');
-insert into roles_users values (0, 0);
-```
 
 #### Running from maven 
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Following list shows all configuration parameters:
 ```
 create table users (id bigint primary key, username varchar(255), salt varchar(255), password varchar(255));
 create table roles (id bigint primary key, name varchar(255));
-create table roles_users (role_id bigint, user_id bigint, constraint roles_users_role_id foreign key (role_id) references roles (id), constraint roles_users_user_id foreign key (user_id) references roles (id));
+create table roles_users (role_id bigint, user_id bigint, constraint roles_users_role_id foreign key (role_id) references roles (id), constraint roles_users_user_id foreign key (user_id) references users (id));
 
 insert into users values (0, 'hawkeye', '8117ec859d0cf945fa9b28075f590707', '13e96bc7ade230967057dd138198dbd02491a8f6871f09b97c351b31a35b5878');
 insert into roles values (0, 'mohican');

--- a/README.md
+++ b/README.md
@@ -31,3 +31,19 @@ Following list shows all configuration parameters:
 * userQuery - SQL query for loading user related data from database (first column is used as salt, second column as password)
 * roleQuery - SQL query for loading the associated roles of the authenticated user
 * debug - activate / deactivate debugging information (optional: default is false) 
+
+#### Database structure example
+```
+create table users (id bigint primary key, username varchar(255), salt varchar(255), password varchar(255));
+create table roles (id bigint primary key, name varchar(255));
+create table roles_users (role_id bigint, user_id bigint, constraint roles_users_role_id foreign key (role_id) references roles (id), constraint roles_users_user_id foreign key (user_id) references roles (id));
+
+insert into users values (0, 'hawkeye', '8117ec859d0cf945fa9b28075f590707', '13e96bc7ade230967057dd138198dbd02491a8f6871f09b97c351b31a35b5878');
+insert into roles values (0, 'mohican');
+insert into roles_users values (0, 0);
+```
+
+#### Running from maven 
+```
+mvn exec:java  -Dexec.args=MyVoiceIsMyPassword
+```

--- a/activemq.md
+++ b/activemq.md
@@ -1,0 +1,61 @@
+#### Activemq
+
+Copy the saltedhash-jaas-module.jar to the activemq/lib directory
+
+##### Database structure example
+
+For postgresql, create 'users' and 'roles' tables as postgresql doesn't allow a table to be named 'user'.
+
+```
+create table users (id bigint primary key, username varchar(255), salt varchar(255), password varchar(255));
+create table roles (id bigint primary key, name varchar(255));
+create table roles_users (role_id bigint, user_id bigint, constraint roles_users_role_id foreign key (role_id) references roles (id), constraint roles_users_user_id foreign key (user_id) references users (id));
+
+insert into users values (0, 'hawkeye', '8117ec859d0cf945fa9b28075f590707', '13e96bc7ade230967057dd138198dbd02491a8f6871f09b97c351b31a35b5878');
+insert into roles values (0, 'mohican');
+insert into roles_users values (0, 0);
+```
+
+##### login.config
+
+The jaas configuration is contained in login.conf  
+Note the use of the role-principal-class module option to use the internal GroupPrincipal principal role class required by activemq.  
+If using postgresql, use the user/role query defined below, and copy the driver jar into the activemq/lib directory.
+
+```
+SaltedHashLoginModule {
+    de.meetwithfriends.security.jaas.SaltedHashLoginModule required
+      dbDriver="org.postgresql.Driver"
+      dbURL="jdbc:postgresql://db.server:5432/amq_db"
+      dbUser="amq_user"
+      dbPassword="amq_passcode"
+      mdAlgorithm="SHA-256"
+      userQuery="select salt, password from users where username = ?"
+      roleQuery="select ro.name from roles ro inner join roles_users rous on ro.id = rous.role_id inner join users us on rous.user_id = us.id where us.username = ?"
+      role-principal-class=org.apache.activemq.jaas.GroupPrincipal
+      debug=true;
+};
+```
+
+
+##### activemq.xml
+
+Add the following example configuration snippet to the activemq.xml plugins element.  
+Customise as required.
+
+```
+<jaasAuthenticationPlugin configuration="SaltedHashLoginModule" />
+<authorizationPlugin>
+    <map>
+        <authorizationMap>
+            <authorizationEntries>
+                <authorizationEntry queue="listener.example"  read="mohican,admins" write="mohican,admins" admin="mohican,admins"/>
+                <authorizationEntry topic="ActiveMQ.Advisory.>"  read="mohican,admins" write="mohican,admins" admin="mohican,admins"/>
+            </authorizationEntries>
+            <tempDestinationAuthorizationEntry>
+                <tempDestinationAuthorizationEntry read="tmp" write="tmp" admin="tmp"/>
+            </tempDestinationAuthorizationEntry>
+        </authorizationMap>
+    </map>
+</authorizationPlugin>
+```

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <name>Salted Hash Jaas LoginModule</name>
     <description>JAAS LoginModule for checking login with salted hashes</description>  
     <inceptionYear>2013</inceptionYear>
-    
+
     <!--
     <licenses>
         <license>
@@ -20,7 +20,7 @@
         </license>
     </licenses>
     -->
-    
+
     <developers>
         <developer>
             <name>Georg Henkel</name>
@@ -28,25 +28,26 @@
             <organizationUrl>http://ww.develman.de</organizationUrl>
         </developer>
     </developers>
-     
+
     <scm>
         <connection>scm:git:git@github.com:Develman/saltedhash-jaas-module.git</connection>
         <url>scm:git:git@github.com:Develman/saltedhash-jaas-module.git</url>
         <developerConnection>scm:git:git@github.com:Develman/saltedhash-jaas-module.git</developerConnection>
     </scm>
-    
+
     <properties>
+        <java.version>8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    
+
     <build>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.0</version>
+                <version>3.5.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
         
@@ -55,7 +56,12 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.4</version>
                 <configuration>
-                    <finalName>saltedhash-jaas-module</finalName>                   
+                    <finalName>saltedhash-jaas-module</finalName>
+                    <archive>
+                        <manifest>
+                            <mainClass>de.meetwithfriends.security.jaas.SaltedHashLoginModule</mainClass>
+                        </manifest>
+                    </archive>
                 </configuration>
             </plugin>
 
@@ -64,32 +70,54 @@
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.4.2</version>
             </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <mainClass>de.meetwithfriends.security.jaas.SaltedHashLoginModule</mainClass>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 
 
     <dependencies>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.32</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.8</version>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.3.174</version>
+            <version>1.4.200</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.9.5</version>
+            <version>4.1.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
                 </executions>
                 <configuration>
                     <mainClass>de.meetwithfriends.security.jaas.SaltedHashLoginModule</mainClass>
+                    <classpathScope>test</classpathScope>
                 </configuration>
             </plugin>
 
@@ -101,6 +102,7 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.2.8</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/src/main/java/de/meetwithfriends/security/jaas/SaltedHashLoginModule.java
+++ b/src/main/java/de/meetwithfriends/security/jaas/SaltedHashLoginModule.java
@@ -5,22 +5,25 @@ import de.meetwithfriends.security.jaas.principal.UserPrincipal;
 import de.meetwithfriends.security.jdbc.AuthenticationDao;
 import de.meetwithfriends.security.jdbc.JdbcAuthenticationService;
 import de.meetwithfriends.security.jdbc.data.ConfigurationData;
+import de.meetwithfriends.security.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.security.Principal;
 import java.text.MessageFormat;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import javax.security.auth.Subject;
 import javax.security.auth.callback.*;
 import javax.security.auth.login.FailedLoginException;
 import javax.security.auth.login.LoginException;
 import javax.security.auth.spi.LoginModule;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
 
 public class SaltedHashLoginModule implements LoginModule
 {
-    private static final Logger LOG = LogManager.getLogger(SaltedHashLoginModule.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SaltedHashLoginModule.class);
 
     private Subject subject;
     private CallbackHandler callbackHandler;
@@ -36,6 +39,18 @@ public class SaltedHashLoginModule implements LoginModule
 
     private boolean succeeded = false;
     private boolean commitSucceeded = false;
+
+    public static void main(String[] args) throws Exception {
+        if (null == args || args.length == 0 || args[0].length() == 0) {
+            LOG.error("need a password arg");
+            throw new IllegalArgumentException("Need a password arg");
+        }
+
+        String salt = StringUtil.getRandomHexString(args.length > 1 ? Integer.parseInt(args[1]) : 32);
+        String password = JdbcAuthenticationService.getSaltedPasswordDigest(args[0], salt, "SHA-256");
+        System.out.println(" Password -> " + password);
+        System.out.println(" Salt -> " + salt);
+    }
 
     @Override
     public void initialize(Subject subject, CallbackHandler callbackHandler,

--- a/src/main/java/de/meetwithfriends/security/jdbc/AuthenticationDao.java
+++ b/src/main/java/de/meetwithfriends/security/jdbc/AuthenticationDao.java
@@ -2,15 +2,16 @@ package de.meetwithfriends.security.jdbc;
 
 import de.meetwithfriends.security.jdbc.data.ConfigurationData;
 import de.meetwithfriends.security.jdbc.data.UserData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
 
 public class AuthenticationDao
 {
-    private static final Logger LOG = LogManager.getLogger(AuthenticationDao.class);
+    private final Logger log = LoggerFactory.getLogger(AuthenticationDao.class);
 
     private ConfigurationData configurationData;
 
@@ -45,7 +46,7 @@ public class AuthenticationDao
         }
         catch (SQLException e)
         {
-            LOG.error("Error when loading user from the database", e);
+            log.error("Error when loading user from the database", e);
         }
         finally
         {
@@ -75,7 +76,7 @@ public class AuthenticationDao
         }
         catch (SQLException e)
         {
-            LOG.error("Error when loading user from the database ", e);
+            log.error("Error when loading user from the database ", e);
         }
         finally
         {
@@ -98,7 +99,7 @@ public class AuthenticationDao
         }
         catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex)
         {
-            LOG.error("Error when creating database connection", ex);
+            log.error("Error when creating database connection", ex);
             throw new RuntimeException("Error when creating database connection: " + ex.getMessage());
         }
 
@@ -116,7 +117,7 @@ public class AuthenticationDao
         }
         catch (Exception ex)
         {
-            LOG.warn("Error closing resource", ex);
+            log.warn("Error closing resource", ex);
         }
     }
 

--- a/src/main/java/de/meetwithfriends/security/util/StringUtil.java
+++ b/src/main/java/de/meetwithfriends/security/util/StringUtil.java
@@ -1,5 +1,7 @@
 package de.meetwithfriends.security.util;
 
+import java.util.Random;
+
 public class StringUtil
 {
     public static String convertToHex(byte[] data)
@@ -13,4 +15,13 @@ public class StringUtil
         return sb.toString();
     }
 
+    public static String getRandomHexString(final int numchars){
+        Random r = new Random();
+        StringBuilder sb = new StringBuilder();
+        while(sb.length() < numchars){
+            sb.append(Integer.toHexString(r.nextInt()));
+        }
+
+        return sb.substring(0, numchars);
+    }
 }

--- a/src/test/java/de/meetwithfriends/security/jaas/Md5LoginModuleTest.java
+++ b/src/test/java/de/meetwithfriends/security/jaas/Md5LoginModuleTest.java
@@ -1,14 +1,17 @@
 package de.meetwithfriends.security.jaas;
 
 import de.meetwithfriends.security.jaas.principal.UserPrincipal;
+
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.sql.*;
 import java.util.Set;
 import javax.security.auth.Subject;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
+
 import org.junit.*;
 
 public class Md5LoginModuleTest
@@ -19,7 +22,7 @@ public class Md5LoginModuleTest
     public void setUp() throws Exception
     {
         URL url = Thread.currentThread().getContextClassLoader().getResource("jaas.config");
-        String p = URLDecoder.decode(url.toExternalForm(), "UTF - 8");
+        String p = URLDecoder.decode(url.toExternalForm(), StandardCharsets.UTF_8.name());
 
         System.setProperty("java.security.auth.login.config", p);
 

--- a/src/test/java/de/meetwithfriends/security/jaas/Sha256LoginModuleTest.java
+++ b/src/test/java/de/meetwithfriends/security/jaas/Sha256LoginModuleTest.java
@@ -3,6 +3,7 @@ package de.meetwithfriends.security.jaas;
 import de.meetwithfriends.security.jaas.principal.UserPrincipal;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.sql.*;
 import java.util.Set;
@@ -19,7 +20,7 @@ public class Sha256LoginModuleTest
     public void setUp() throws Exception
     {
         URL url = Thread.currentThread().getContextClassLoader().getResource("jaas.config");
-        String p = URLDecoder.decode(url.toExternalForm(), "UTF - 8");
+        String p = URLDecoder.decode(url.toExternalForm(), StandardCharsets.UTF_8.name());
 
         System.setProperty("java.security.auth.login.config", p);
 

--- a/src/test/java/de/meetwithfriends/security/jdbc/JdbcAuthenticationServiceTest.java
+++ b/src/test/java/de/meetwithfriends/security/jdbc/JdbcAuthenticationServiceTest.java
@@ -39,7 +39,7 @@ public class JdbcAuthenticationServiceTest
 
     private void initStubs()
     {
-        Mockito.when(authenticationDao.loadUserData(Matchers.anyString())).thenAnswer(new Answer<UserData>()
+        Mockito.when(authenticationDao.loadUserData(ArgumentMatchers.anyString())).thenAnswer(new Answer<UserData>()
         {
 
             @Override


### PR DESCRIPTION
add exec configuration in pom to allow 
add samples sql for creation of tables
add / modify code to generate a salted sha256 message digest (password) from the command line
switch to slf4j and logback
add main method for generating password from command line
bump some dependencies
bump to java 8